### PR TITLE
Fix VBox-Loader

### DIFF
--- a/dissect/hypervisor/__init__.py
+++ b/dissect/hypervisor/__init__.py
@@ -1,6 +1,6 @@
 from dissect.hypervisor.backup import vma, wim, xva
 from dissect.hypervisor.disk import qcow2, vdi, vhd, vhdx, vmdk
-from dissect.hypervisor.descriptor import hyperv, ovf, vmx
+from dissect.hypervisor.descriptor import hyperv, ovf, vmx, vbox
 from dissect.hypervisor.util import envelope, vmtar
 
 
@@ -9,6 +9,7 @@ __all__ = [
     "hyperv",
     "ovf",
     "qcow2",
+    "vbox",
     "vdi",
     "vhd",
     "vhdx",

--- a/dissect/hypervisor/descriptor/vbox.py
+++ b/dissect/hypervisor/descriptor/vbox.py
@@ -1,0 +1,15 @@
+from xml.etree import ElementTree
+
+
+class VBox:
+
+    VBOX_XML_NAMESPACE = "{http://www.virtualbox.org/}"
+
+    def __init__(self, fh):
+        self._xml = ElementTree.fromstring(fh.read())
+
+    def disks(self):
+        for hdd_elem in self._xml.findall(
+            f".//{self.VBOX_XML_NAMESPACE}HardDisk[@location][@format='VDI'][@type='Normal']"
+        ):
+            yield hdd_elem.attrib["location"]

--- a/dissect/hypervisor/disk/vdi.py
+++ b/dissect/hypervisor/disk/vdi.py
@@ -67,18 +67,13 @@ class VDI(AlignedStream):
 
 
 class Vbox:
-    def __init__(self, fh):
-        self.fh = fh
-        self.xml = ElementTree.fromstring(fh.read())
 
-        self.machine = list(self.xml)[0]
-        self.registry = next((elem for elem in self.machine if "MediaRegistry" in elem.tag))
+    VBOX_XML_NAMESPACE = "{http://www.virtualbox.org/}"
+
+    def __init__(self, fh):
+        xml = ElementTree.fromstring(fh.read())
+        self._disks = xml.findall(f".//{self.VBOX_XML_NAMESPACE}HardDisk[@location][@format='VDI'][@type='Normal']")
 
     def disks(self):
-        for hdd_elem in next((elem for elem in self.registry if "HardDisks" in elem.tag)):
+        for hdd_elem in self._disks:
             yield hdd_elem.attrib["location"]
-
-    def snapshots(self):
-        for hdd_elem in next((elem for elem in self.registry if "HardDisks" in elem.tag)):
-            for snap_elem in hdd_elem:
-                yield hdd_elem.attrib["location"], snap_elem.attrib["location"]

--- a/dissect/hypervisor/disk/vdi.py
+++ b/dissect/hypervisor/disk/vdi.py
@@ -1,15 +1,8 @@
 import array
 
-from xml.etree import ElementTree
-
 from dissect.util.stream import AlignedStream
 
-from dissect.hypervisor.disk.c_vdi import (
-    c_vdi,
-    SPARSE,
-    UNALLOCATED,
-    VDI_SIGNATURE,
-)
+from dissect.hypervisor.disk.c_vdi import SPARSE, UNALLOCATED, VDI_SIGNATURE, c_vdi
 from dissect.hypervisor.exceptions import Error
 
 
@@ -64,15 +57,3 @@ class VDI(AlignedStream):
             block_idx += 1
 
         return b"".join(bytes_read)
-
-
-class Vbox:
-
-    VBOX_XML_NAMESPACE = "{http://www.virtualbox.org/}"
-
-    def __init__(self, fh):
-        self._xml = ElementTree.fromstring(fh.read())
-
-    def disks(self):
-        for hdd_elem in self._xml.findall(f".//{self.VBOX_XML_NAMESPACE}HardDisk[@location][@format='VDI'][@type='Normal']"):
-            yield hdd_elem.attrib["location"]

--- a/dissect/hypervisor/disk/vdi.py
+++ b/dissect/hypervisor/disk/vdi.py
@@ -71,8 +71,8 @@ class Vbox:
     VBOX_XML_NAMESPACE = "{http://www.virtualbox.org/}"
 
     def __init__(self, fh):
-        self.xml = ElementTree.fromstring(fh.read())
+        self._xml = ElementTree.fromstring(fh.read())
 
     def disks(self):
-        for hdd_elem in self.xml.findall(f".//{self.VBOX_XML_NAMESPACE}HardDisk[@location][@format='VDI'][@type='Normal']"):
+        for hdd_elem in self._xml.findall(f".//{self.VBOX_XML_NAMESPACE}HardDisk[@location][@format='VDI'][@type='Normal']"):
             yield hdd_elem.attrib["location"]

--- a/dissect/hypervisor/disk/vdi.py
+++ b/dissect/hypervisor/disk/vdi.py
@@ -74,5 +74,5 @@ class Vbox:
         self.xml = ElementTree.fromstring(fh.read())
 
     def disks(self):
-        for hdd_elem in self._disks:
+        for hdd_elem in self.xml.findall(f".//{self.VBOX_XML_NAMESPACE}HardDisk[@location][@format='VDI'][@type='Normal']"):
             yield hdd_elem.attrib["location"]

--- a/dissect/hypervisor/disk/vdi.py
+++ b/dissect/hypervisor/disk/vdi.py
@@ -71,8 +71,7 @@ class Vbox:
     VBOX_XML_NAMESPACE = "{http://www.virtualbox.org/}"
 
     def __init__(self, fh):
-        xml = ElementTree.fromstring(fh.read())
-        self._disks = xml.findall(f".//{self.VBOX_XML_NAMESPACE}HardDisk[@location][@format='VDI'][@type='Normal']")
+        self.xml = ElementTree.fromstring(fh.read())
 
     def disks(self):
         for hdd_elem in self._disks:

--- a/tests/test_vbox.py
+++ b/tests/test_vbox.py
@@ -1,6 +1,6 @@
 from io import StringIO
 
-from dissect.hypervisor.disk.vdi import Vbox
+from dissect.hypervisor.descriptor.vbox import VBox
 
 
 def test_vbox():
@@ -19,5 +19,5 @@ def test_vbox():
     """
 
     with StringIO(xml.strip()) as fh:
-        vbox = Vbox(fh)
+        vbox = VBox(fh)
         assert next(vbox.disks()) == "os2warp4.vdi"

--- a/tests/test_vbox.py
+++ b/tests/test_vbox.py
@@ -1,0 +1,22 @@
+from io import StringIO
+
+from dissect.hypervisor.disk.vdi import Vbox
+
+
+def test_vbox():
+
+    xml = """<?xml version="1.0"?>
+                <VirtualBox xmlns="http://www.virtualbox.org/">
+                    <Machine>
+                        <MediaRegistry>
+                            <HardDisks>
+                                <HardDisk location="os2warp4.vdi" format="VDI" type="Normal" />
+                            </HardDisks>
+                        </MediaRegistry>
+                    </Machine>
+                </VirtualBox>
+    """
+
+    with StringIO(xml) as fh:
+        vbox = Vbox(fh)
+        assert next(vbox.disks()) == "os2warp4.vdi"

--- a/tests/test_vbox.py
+++ b/tests/test_vbox.py
@@ -5,18 +5,19 @@ from dissect.hypervisor.disk.vdi import Vbox
 
 def test_vbox():
 
-    xml = """<?xml version="1.0"?>
-                <VirtualBox xmlns="http://www.virtualbox.org/">
-                    <Machine>
-                        <MediaRegistry>
-                            <HardDisks>
-                                <HardDisk location="os2warp4.vdi" format="VDI" type="Normal" />
-                            </HardDisks>
-                        </MediaRegistry>
-                    </Machine>
-                </VirtualBox>
+    xml = """
+    <?xml version="1.0"?>
+    <VirtualBox xmlns="http://www.virtualbox.org/">
+        <Machine>
+            <MediaRegistry>
+                <HardDisks>
+                    <HardDisk location="os2warp4.vdi" format="VDI" type="Normal" />
+                </HardDisks>
+            </MediaRegistry>
+        </Machine>
+    </VirtualBox>
     """
 
-    with StringIO(xml) as fh:
+    with StringIO(xml.strip()) as fh:
         vbox = Vbox(fh)
         assert next(vbox.disks()) == "os2warp4.vdi"


### PR DESCRIPTION
Fix VBox Loader and use XPath instead of manually walking over XML-nodes.
Remove snapshots() method as these are not supported yet.

(DIS-1430)
