### PR TITLE
VMA Fixes

### DIFF
--- a/dissect/hypervisor/backup/vma.py
+++ b/dissect/hypervisor/backup/vma.py
@@ -215,19 +215,19 @@ class DeviceDataStream(AlignedStream):
         return b"".join(result)
 
 
-def _iter_clusters(vma, device, cluster, count):
+def _iter_clusters(vma, dev_id, cluster, count):
     # Find clusters and starting offsets in all extents
     temp = {}
     end = cluster + count
 
     for extent in vma.extents():
-        if device not in extent.blocks:
+        if dev_id not in extent.blocks:
             continue
 
-        if end < extent._min[device] or cluster > extent._max[device]:
+        if end < extent._min[dev_id] or cluster > extent._max[dev_id]:
             continue
 
-        for cluster_num, mask, block_offset in extent.blocks[device]:
+        for cluster_num, mask, block_offset in extent.blocks[dev_id]:
             if cluster_num == cluster:
                 yield cluster_num, mask, block_offset
                 cluster += 1

--- a/dissect/hypervisor/backup/vma.py
+++ b/dissect/hypervisor/backup/vma.py
@@ -67,6 +67,8 @@ class VMA:
 
             self._devices[dev_id] = Device(self, dev_id, self.blob_string(dev_info.devname_ptr), dev_info.size)
 
+        self.extent = @lru_cache(65536)(self.extent)
+
     @property
     def creation_time(self):
         return ts.from_unix(self.header.ctime)
@@ -91,7 +93,6 @@ class VMA:
     def devices(self):
         return list(self._devices.values())
 
-    @lru_cache(65536)
     def _extent(self, offset):
         return Extent(self.fh, offset)
 

--- a/dissect/hypervisor/backup/vma.py
+++ b/dissect/hypervisor/backup/vma.py
@@ -67,7 +67,7 @@ class VMA:
 
             self._devices[dev_id] = Device(self, dev_id, self.blob_string(dev_info.devname_ptr), dev_info.size)
 
-        self.extent = @lru_cache(65536)(self.extent)
+        self._extent = @lru_cache(65536)(self._extent)
 
     @property
     def creation_time(self):

--- a/dissect/hypervisor/backup/vma.py
+++ b/dissect/hypervisor/backup/vma.py
@@ -221,7 +221,7 @@ def _iter_clusters(vma, device, cluster, count):
     end = cluster + count
 
     for extent in vma.extents():
-        if device not in extent._min:
+        if device not in extent.blocks:
             continue
 
         if end < extent._min[device] or cluster > extent._max[device]:

--- a/dissect/hypervisor/tools/vma.py
+++ b/dissect/hypervisor/tools/vma.py
@@ -135,7 +135,7 @@ def main():
         with progress:
             try:
                 for extent in vma.extents():
-                    data_offset = extent.data_offset
+                    vma.fh.seek(extent.data_offset)
                     for block_info in extent.header.blockinfo:
                         cluster_num = block_info & 0xFFFFFFFF
                         dev_id = (block_info >> 32) & 0xFF
@@ -147,7 +147,6 @@ def main():
                         fh_out = handles[dev_id]
                         fh_out.seek(cluster_num * c_vma.VMA_CLUSTER_SIZE)
 
-                        vma.fh.seek(data_offset)
                         if mask == 0xFFFF:
                             fh_out.write(vma.fh.read(c_vma.VMA_CLUSTER_SIZE))
                         elif mask == 0:

--- a/dissect/hypervisor/tools/vma.py
+++ b/dissect/hypervisor/tools/vma.py
@@ -94,7 +94,7 @@ def setup_logging(logger, verbosity):
 def main():
     parser = argparse.ArgumentParser(description="VMA extractor")
     parser.add_argument("input", type=Path, help="path to vma file")
-    parser.add_argument("-o", "--output", type=Path, help="path to output directory")
+    parser.add_argument("-o", "--output", type=Path, required=True, help="path to output directory")
     parser.add_argument("-v", "--verbose", action="count", default=3, help="increase output verbosity")
     args = parser.parse_args()
 


### PR DESCRIPTION
Two bugs related to VMA are covered in this PR:

- vma-extract had a seek to the start of the data inside an extent in the wrong place (within the loop over the blocks instead of before the loop) 
- A logic-bug related to the fact  that inside an extent, blocks of multiple devices could be stored. These blocks should be handled in the loop inside `_iter_clusters` as well, in order to return the right `block_offset`.