### PR TITLE
Make HDD file check less strict

### DIFF
--- a/dissect/hypervisor/disk/hdd.py
+++ b/dissect/hypervisor/disk/hdd.py
@@ -30,7 +30,7 @@ class HDD:
     """
 
     def __init__(self, path: Path):
-        if path.is_file() and path.parent.suffix.lower() == ".hdd":
+        if path.is_file():
             path = path.parent
         self.path = path
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,98 +1,99 @@
 import gzip
 import os
+from typing import BinaryIO, Iterator, TextIO
 
 import pytest
 
 
-def absolute_path(filename):
+def absolute_path(filename) -> str:
     return os.path.join(os.path.dirname(__file__), filename)
 
 
-def open_file(name, mode="rb"):
+def open_file(name: str, mode: str = "rb") -> Iterator[BinaryIO]:
     with open(absolute_path(name), mode) as f:
         yield f
 
 
-def open_file_gz(name, mode="rb"):
+def open_file_gz(name: str, mode: str = "rb") -> Iterator[BinaryIO]:
     with gzip.GzipFile(absolute_path(name), mode) as f:
         yield f
 
 
 @pytest.fixture
-def encrypted_vmx():
+def encrypted_vmx() -> Iterator[BinaryIO]:
     yield from open_file("data/encrypted.vmx")
 
 
 @pytest.fixture
-def vmcx():
+def vmcx() -> Iterator[BinaryIO]:
     yield from open_file("data/test.vmcx")
 
 
 @pytest.fixture
-def vmrs():
+def vmrs() -> Iterator[BinaryIO]:
     yield from open_file("data/test.VMRS")
 
 
 @pytest.fixture
-def fixed_vhd():
+def fixed_vhd() -> Iterator[BinaryIO]:
     yield from open_file_gz("data/fixed.vhd.gz")
 
 
 @pytest.fixture
-def dynamic_vhd():
+def dynamic_vhd() -> Iterator[BinaryIO]:
     yield from open_file_gz("data/dynamic.vhd.gz")
 
 
 @pytest.fixture
-def fixed_vhdx():
+def fixed_vhdx() -> Iterator[BinaryIO]:
     yield from open_file_gz("data/fixed.vhdx.gz")
 
 
 @pytest.fixture
-def dynamic_vhdx():
+def dynamic_vhdx() -> Iterator[BinaryIO]:
     yield from open_file_gz("data/dynamic.vhdx.gz")
 
 
 @pytest.fixture
-def differencing_vhdx():
+def differencing_vhdx() -> Iterator[BinaryIO]:
     yield from open_file_gz("data/differencing.avhdx.gz")
 
 
 @pytest.fixture
-def sesparse_vmdk():
+def sesparse_vmdk() -> Iterator[BinaryIO]:
     yield from open_file_gz("data/sesparse.vmdk.gz")
 
 
 @pytest.fixture
-def plain_hdd():
+def plain_hdd() -> Iterator[str]:
     yield absolute_path("data/plain.hdd")
 
 
 @pytest.fixture
-def expanding_hdd():
+def expanding_hdd() -> Iterator[str]:
     yield absolute_path("data/expanding.hdd")
 
 
 @pytest.fixture
-def split_hdd():
+def split_hdd() -> Iterator[str]:
     yield absolute_path("data/split.hdd")
 
 
 @pytest.fixture
-def simple_vma():
+def simple_vma() -> Iterator[BinaryIO]:
     yield from open_file_gz("data/test.vma.gz")
 
 
 @pytest.fixture
-def envelope():
+def envelope() -> Iterator[BinaryIO]:
     yield from open_file("data/local.tgz.ve")
 
 
 @pytest.fixture
-def keystore():
+def keystore() -> Iterator[TextIO]:
     yield from open_file("data/encryption.info", "r")
 
 
 @pytest.fixture
-def vgz():
+def vgz() -> Iterator[BinaryIO]:
     yield from open_file("data/test.vgz")

--- a/tests/test_hdd.py
+++ b/tests/test_hdd.py
@@ -1,5 +1,6 @@
 import gzip
 from pathlib import Path
+from typing import BinaryIO
 from unittest.mock import patch
 
 from dissect.hypervisor.disk.hdd import HDD
@@ -7,14 +8,14 @@ from dissect.hypervisor.disk.hdd import HDD
 Path_open = Path.open
 
 
-def mock_open_gz(self, *args, **kwargs):
+def mock_open_gz(self, *args, **kwargs) -> BinaryIO:
     if self.suffix.lower() != ".hds":
         return Path_open(self, *args, **kwargs)
 
     return gzip.open(self.with_suffix(self.suffix + ".gz"))
 
 
-def test_plain_hdd(plain_hdd):
+def test_plain_hdd(plain_hdd: str) -> None:
     hdd = HDD(Path(plain_hdd))
     storages = hdd.descriptor.storage_data.storages
 
@@ -31,7 +32,7 @@ def test_plain_hdd(plain_hdd):
             assert stream.read(1024 * 1024).strip(bytes([i])) == b""
 
 
-def test_expanding_hdd(expanding_hdd):
+def test_expanding_hdd(expanding_hdd: str) -> None:
     hdd = HDD(Path(expanding_hdd))
     storages = hdd.descriptor.storage_data.storages
 
@@ -48,7 +49,7 @@ def test_expanding_hdd(expanding_hdd):
             assert stream.read(1024 * 1024).strip(bytes([i])) == b""
 
 
-def test_split_hdd(split_hdd):
+def test_split_hdd(split_hdd: str) -> None:
     hdd = HDD(Path(split_hdd))
     storages = hdd.descriptor.storage_data.storages
 
@@ -81,3 +82,10 @@ def test_split_hdd(split_hdd):
                 assert buf == bytes([i + 1] * 512) + bytes([i + 2] * 512)
             else:
                 assert buf == bytes([i + 1] * 512)
+
+
+def test_file_use_parent(plain_hdd: str) -> None:
+    hdd = HDD(Path(plain_hdd).joinpath("plain.hdd"))
+    storages = hdd.descriptor.storage_data.storages
+
+    assert len(storages) == 1


### PR DESCRIPTION
Remove the check if the parent directory has a `.hdd` extension. Loading should be dependent on if the `DiskDescriptor.xml` is present or not, which is checked a few lines later.

Fixes #22.