### PR TITLE
Fix detection of vdi harddisks inside a vbox file.

### DIFF
--- a/dissect/hypervisor/descriptor/vbox.py
+++ b/dissect/hypervisor/descriptor/vbox.py
@@ -13,6 +13,5 @@ class VBox:
     def disks(self) -> Iterator[str]:
         for hdd_elem in self._xml.findall(f".//{self.VBOX_XML_NAMESPACE}HardDisk[@location][@type='Normal']"):
             # Allow format specifier to be case-insensitive (i.e. VDI, vdi)
-            format_attr = hdd_elem.get("format")
-            if format_attr and format_attr.lower() == "vdi":
+            if (format := hdd_elem.get("format")) and format.lower() == "vdi":
                 yield hdd_elem.attrib["location"]

--- a/dissect/hypervisor/descriptor/vbox.py
+++ b/dissect/hypervisor/descriptor/vbox.py
@@ -11,7 +11,8 @@ class VBox:
         self._xml: Element = ElementTree.fromstring(fh.read())
 
     def disks(self) -> Iterator[str]:
-        for hdd_elem in self._xml.findall(
-            f".//{self.VBOX_XML_NAMESPACE}HardDisk[@location][@format='VDI'][@type='Normal']"
-        ):
-            yield hdd_elem.attrib["location"]
+        for hdd_elem in self._xml.findall(f".//{self.VBOX_XML_NAMESPACE}HardDisk[@location][@type='Normal']"):
+            # Allow format specifier to be case-insensitive (i.e. VDI, vdi)
+            format_attr = hdd_elem.get("format")
+            if format_attr and format_attr.lower() == "vdi":
+                yield hdd_elem.attrib["location"]

--- a/tests/test_vbox.py
+++ b/tests/test_vbox.py
@@ -20,3 +20,22 @@ def test_vbox():
     with StringIO(xml.strip()) as fh:
         vbox = VBox(fh)
         assert next(vbox.disks()) == "os2warp4.vdi"
+
+
+def test_vbox_lowercase_disk_format():
+    xml = """
+    <?xml version="1.0"?>
+    <VirtualBox xmlns="http://www.virtualbox.org/">
+        <Machine>
+            <MediaRegistry>
+                <HardDisks>
+                    <HardDisk location="WinDev2407Eval-disk001.vdi" format="vdi" type="Normal" />
+                </HardDisks>
+            </MediaRegistry>
+        </Machine>
+    </VirtualBox>
+    """
+
+    with StringIO(xml.strip()) as fh:
+        vbox = VBox(fh)
+        assert next(vbox.disks()) == "WinDev2407Eval-disk001.vdi"

--- a/tests/test_vbox.py
+++ b/tests/test_vbox.py
@@ -3,7 +3,7 @@ from io import StringIO
 from dissect.hypervisor.descriptor.vbox import VBox
 
 
-def test_vbox():
+def test_vbox() -> None:
     xml = """
     <?xml version="1.0"?>
     <VirtualBox xmlns="http://www.virtualbox.org/">
@@ -22,7 +22,7 @@ def test_vbox():
         assert next(vbox.disks()) == "os2warp4.vdi"
 
 
-def test_vbox_lowercase_disk_format():
+def test_vbox_lowercase_disk_format() -> None:
     xml = """
     <?xml version="1.0"?>
     <VirtualBox xmlns="http://www.virtualbox.org/">


### PR DESCRIPTION
Sometimes the vbox configuration file might specifiy the format attribute of a HardDisk using lower case (vdi).  

This patch ensures that both lower and upper case are supported.

Closes #43 
