### PR TITLE
Improve QCow2 to support automatic backing file resolution

### DIFF
--- a/dissect/hypervisor/disk/qcow2.py
+++ b/dissect/hypervisor/disk/qcow2.py
@@ -117,7 +117,7 @@ class QCow2(AlignedStream):
             self.image_backing_file = self.auto_backing_file.upper()
 
             if backing_file is None:
-                if hasattr(f, 'read'):
+                if not isinstance(fh, Path):
                     raise Error(f"backing-file required but not provided (auto_backing_file = {self.auto_backing_file})")
                 candidate_path = Path(f).parent / self.auto_backing_file
                 if not candidate_path.exists():

--- a/dissect/hypervisor/disk/qcow2.py
+++ b/dissect/hypervisor/disk/qcow2.py
@@ -52,10 +52,7 @@ class QCow2(AlignedStream):
     """
 
     def __init__(self, fh: BinaryIO | Path, data_file: BinaryIO  | None = None, backing_file: BinaryIO | int | None = None):
-        f = fh
-        if not hasattr(fh, "read"):
-            fh = f.open("rb")
-        self.fh = fh
+        self.fh = fh.open("rb") if isinstance(fh, Path) else fh
 
         self.header = c_qcow2.QCowHeader(fh)
         if self.header.magic != QCOW2_MAGIC:

--- a/dissect/hypervisor/disk/qcow2.py
+++ b/dissect/hypervisor/disk/qcow2.py
@@ -7,6 +7,7 @@ import copy
 import zlib
 from functools import cached_property, lru_cache
 from io import BytesIO
+from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
 from dissect.util.stream import AlignedStream
@@ -50,7 +51,10 @@ class QCow2(AlignedStream):
     in all null bytes being read.
     """
 
-    def __init__(self, fh: BinaryIO, data_file: BinaryIO | None = None, backing_file: BinaryIO | int | None = None):
+    def __init__(self, fh: BinaryIO | Path, data_file: BinaryIO  | None = None, backing_file: BinaryIO | int | None = None):
+        f = fh
+        if not hasattr(fh, "read"):
+            fh = f.open("rb")
         self.fh = fh
 
         self.header = c_qcow2.QCowHeader(fh)
@@ -116,7 +120,12 @@ class QCow2(AlignedStream):
             self.image_backing_file = self.auto_backing_file.upper()
 
             if backing_file is None:
-                raise Error(f"backing-file required but not provided (auto_backing_file = {self.auto_backing_file})")
+                if hasattr(f, 'read'):
+                    raise Error(f"backing-file required but not provided (auto_backing_file = {self.auto_backing_file})")
+                candidate_path = Path(f).parent / self.auto_backing_file
+                if not candidate_path.exists():
+                    raise Error(f"backing-file '{candidate_path}' not found (auto_backing_file = '{self.auto_backing_file}')")
+                backing_file = candidate_path.open("rb")
 
             if backing_file != ALLOW_NO_BACKING_FILE:
                 self.backing_file = backing_file

--- a/dissect/hypervisor/disk/qcow2.py
+++ b/dissect/hypervisor/disk/qcow2.py
@@ -51,7 +51,7 @@ class QCow2(AlignedStream):
     in all null bytes being read.
     """
 
-    def __init__(self, fh: BinaryIO | Path, data_file: BinaryIO  | None = None, backing_file: BinaryIO | int | None = None):
+    def __init__(self, fh: BinaryIO | Path, data_file: BinaryIO | None = None, backing_file: BinaryIO | int | None = None):
         self.fh = fh.open("rb") if isinstance(fh, Path) else fh
 
         self.header = c_qcow2.QCowHeader(fh)

--- a/dissect/hypervisor/disk/qcow2.py
+++ b/dissect/hypervisor/disk/qcow2.py
@@ -51,7 +51,9 @@ class QCow2(AlignedStream):
     in all null bytes being read.
     """
 
-    def __init__(self, fh: BinaryIO | Path, data_file: BinaryIO | None = None, backing_file: BinaryIO | int | None = None):
+    def __init__(
+        self, fh: BinaryIO | Path, data_file: BinaryIO | None = None, backing_file: BinaryIO | int | None = None
+    ):
         self.fh = fh.open("rb") if isinstance(fh, Path) else fh
 
         self.header = c_qcow2.QCowHeader(fh)
@@ -118,9 +120,13 @@ class QCow2(AlignedStream):
 
             if backing_file is None:
                 if not isinstance(fh, Path):
-                    raise Error(f"backing-file required but not provided (auto_backing_file = {self.auto_backing_file})")
+                    raise Error(
+                        f"backing-file required but not provided (auto_backing_file = {self.auto_backing_file})"
+                    )
                 if not (candidate_path := fh.parent.joinpath(self.auto_backing_file)).exists():
-                    raise Error(f"backing-file '{candidate_path}' not found (auto_backing_file = '{self.auto_backing_file}')")
+                    raise Error(
+                        f"backing-file '{candidate_path}' not found (auto_backing_file = '{self.auto_backing_file}')"
+                    )
                 backing_file = candidate_path.open("rb")
 
             if backing_file != ALLOW_NO_BACKING_FILE:

--- a/dissect/hypervisor/disk/qcow2.py
+++ b/dissect/hypervisor/disk/qcow2.py
@@ -119,8 +119,7 @@ class QCow2(AlignedStream):
             if backing_file is None:
                 if not isinstance(fh, Path):
                     raise Error(f"backing-file required but not provided (auto_backing_file = {self.auto_backing_file})")
-                candidate_path = Path(f).parent / self.auto_backing_file
-                if not candidate_path.exists():
+                if not (candidate_path := fh.parent.joinpath(self.auto_backing_file)).exists():
                     raise Error(f"backing-file '{candidate_path}' not found (auto_backing_file = '{self.auto_backing_file}')")
                 backing_file = candidate_path.open("rb")
 


### PR DESCRIPTION
This PR partially solves [this issue](https://github.com/fox-it/dissect.target/issues/1154).

- Allow the QCow2 constructor to accept a `Path` object for `fh
- If a backing file is detected, automatically attempt to open it relative to fh path's.

Note: Providing a Qcow2 image with a backing file will work only if the fh is passed as a Path obj.

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->

