### PR TITLE
Rewind file pointer and be compatible with 3.13.13

### DIFF
--- a/dissect/hypervisor/util/vmtar.py
+++ b/dissect/hypervisor/util/vmtar.py
@@ -22,9 +22,8 @@ class VisorTarInfo(tarfile.TarInfo):
     fixUpPgs: int | None
 
     @classmethod
-    def frombuf(cls, buf: bytes, encoding: str, errors: str) -> VisorTarInfo:
-        obj = super().frombuf(buf, encoding, errors)
-
+    def _init_visor_attrs(cls, obj: VisorTarInfo, buf: bytes) -> None:
+        """Initialize visor-specific attributes from the raw header buffer."""
         obj.is_visor = buf[257:264] == b"visor  "
         if obj.is_visor:
             obj.offset_data = struct.unpack("<I", buf[496:500])[0]
@@ -35,6 +34,19 @@ class VisorTarInfo(tarfile.TarInfo):
             obj.textPgs = None
             obj.fixUpPgs = None
 
+    @classmethod
+    def frombuf(cls, buf: bytes, encoding: str, errors: str) -> VisorTarInfo:
+        obj = super().frombuf(buf, encoding, errors)
+        cls._init_visor_attrs(obj, buf)
+        return obj
+
+    @classmethod
+    def _frombuf(cls, buf: bytes, encoding: str, errors: str, **kwargs) -> VisorTarInfo:
+        # Python 3.13.13+ refactored tarfile to call _frombuf directly instead of
+        # frombuf in fromtarfile and _proc_gnulong/_proc_pax. We must override _frombuf
+        # to ensure visor-specific attributes are initialized for all code paths.
+        obj = super()._frombuf(buf, encoding, errors, **kwargs)
+        cls._init_visor_attrs(obj, buf)
         return obj
 
     def _proc_member(self, tarfile: tarfile.TarFile) -> VisorTarInfo | tarfile.TarInfo:
@@ -76,6 +88,8 @@ class VisorTarFile(tarfile.TarFile):
         try:
             t = cls.taropen(name, mode, fileobj, **kwargs)
         except Exception:
+            if fileobj is not None:
+                fileobj.seek(0)
             try:
                 fileobj = GzipFile(name, mode + "b", fileobj=fileobj)
             except OSError as e:
@@ -103,10 +117,12 @@ class VisorTarFile(tarfile.TarFile):
             compressed = True
 
         # If we get here, we have a valid visor tar file
-        if fileobj is not None and compressed:
-            # Just read the entire file into memory, it's probably small
+        if fileobj is not None:
             fileobj.seek(0)
-            fileobj = BytesIO(fileobj.read())
+            if compressed:
+                # GzipFile/LZMAFile are not seekable, but TarFile requires seek/tell.
+                # Read the decompressed data into a BytesIO to make it seekable.
+                fileobj = BytesIO(fileobj.read())
 
         t = cls.taropen(name, mode, fileobj, **kwargs)
 

--- a/dissect/hypervisor/util/vmtar.py
+++ b/dissect/hypervisor/util/vmtar.py
@@ -120,8 +120,7 @@ class VisorTarFile(tarfile.TarFile):
         if fileobj is not None:
             fileobj.seek(0)
             if compressed:
-                # GzipFile/LZMAFile are not seekable, but TarFile requires seek/tell.
-                # Read the decompressed data into a BytesIO to make it seekable.
+                # Read the decompressed data into a BytesIO to make random reads faster
                 fileobj = BytesIO(fileobj.read())
 
         t = cls.taropen(name, mode, fileobj, **kwargs)

--- a/tests/util/test_vmtar.py
+++ b/tests/util/test_vmtar.py
@@ -21,6 +21,7 @@ def test_vmtar() -> None:
         # The test file has no textPgs/fixUpPgs
         assert all(member.is_visor for member in members.values())
         assert set(members.keys()) == {
+            "test",
             "test/file1",
             "test/file2",
             "test/file3",


### PR DESCRIPTION
Two fixes:

Problem:
We did not rewind the file pointer for uncompressed vmtar files, skipping the first entry

Problem: 
Python3.13.13 bypasses frombuf and directly calls _frombuf

(Found by nightly monorepo ci)

It seems our current CI is still using 3.13.12